### PR TITLE
Fix hearbeat check if pcntl is unavailable

### DIFF
--- a/PhpAmqpLib/Wire/IO/StreamIO.php
+++ b/PhpAmqpLib/Wire/IO/StreamIO.php
@@ -233,6 +233,8 @@ class StreamIO extends AbstractIO
                 if ($this->canDispatchPcntlSignal) {
                     $this->select(0, self::READ_BUFFER_WAIT_INTERVAL);
                     pcntl_signal_dispatch();
+                } else {
+                    $this->check_heartbeat();
                 }
                 continue;
             }


### PR DESCRIPTION
If the socket is broken and pcntl is not available, the read method were stuck in an endless loop.
This change checks the hearbeat if no data is read from the stream (potential dead stream).